### PR TITLE
Add minimum disk capacity to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ So, assume you want to create the following setup:
 -	ScaleIO Secondary MDM and SDS - 192.168.1.2 - Using /dev/sdb and /dev/sdc
 -	ScaleIO Primary MDM and SDS and API gateway - 192.168.1.3 - Using /dev/sdb and /dev/sdc
 
-Existing data on /dev/sdb and /dev/sdc will be lost.
+Existing data on /dev/sdb and /dev/sdc will be lost. ScaleIO requires that you use a minimum of three SDS servers, with a combined free capacity of at least 200 GB.
 
 To create a new cluster, you just need to run the following commands:
 


### PR DESCRIPTION
According to "ScaleIO User Guide", the disks from the 3 SDS servers
should be have at least 200GB capacity. Otherwise a
SDS_ADD_DEV_SIZE_PROBLEM, i.e. "SDS device size error", will be
thrown when adding SDS server.
