### PR TITLE
Enable shell debugging in container start.sh

### DIFF
--- a/scaleio-primary-mdm/Dockerfile
+++ b/scaleio-primary-mdm/Dockerfile
@@ -7,6 +7,7 @@ RUN yum -y install bash-completion
 ADD . /opt/emc/scaleio/siinstall/
 
 RUN printf "#!/bin/sh \n\
+set -x \n\
 umount /dev/shm \n\
 mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime,size=524288k shm /dev/shm \n\
 rpm -qa | egrep -i 'ecs|scaleio' \n\

--- a/scaleio-secondary-mdm/Dockerfile
+++ b/scaleio-secondary-mdm/Dockerfile
@@ -7,6 +7,7 @@ RUN yum -y install bash-completion
 ADD . /opt/emc/scaleio/siinstall/
 
 RUN printf "#!/bin/sh \n\
+set -x \n\
 umount /dev/shm \n\
 mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime,size=524288k shm /dev/shm \n\
 rpm -qa | egrep -i 'ecs|scaleio' \n\

--- a/scaleio-tb/Dockerfile
+++ b/scaleio-tb/Dockerfile
@@ -7,6 +7,7 @@ RUN yum -y install bash-completion
 ADD . /opt/emc/scaleio/siinstall/
 
 RUN printf "#!/bin/sh \n\
+set -x \n\
 rpm -qa | egrep -i 'ecs|scaleio' \n\
 if ((\$? != 0 )); then \n\
   rpm -Uvh /opt/emc/scaleio/siinstall/EMC-ScaleIO-tb-*.x86_64.rpm \n\


### PR DESCRIPTION
With set -x the shell prints debug tracing. If scaleio
failed to start, user could use docker logs <container-id> to
find where it stops. Otherwise even if the user logged into the
container, the current progress of start.sh would be hard to find.
